### PR TITLE
Use mongoose PromiseProvider to enable ES2015 Promise compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-fill",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Mongoose.js add-on that adds virtual (temporary) async fileds API",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "mongoose": "^4.0.5",
+    "mongoose": "^4.1.2",
     "tape": "^4.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
When using mongoose-fill and a promise provider other than the current default of mpromise in mongoose (as per http://mongoosejs.com/docs/promises.html#plugging-in-your-own-promises-library ), you receive an error "Can't use ES6 promise with mpromise style constructor" when trying to `fill` a query.

This change modifies mongoose-fill to use the new mongoose PromiseProvider and ES6 style promises so mongoose-fill is compatible with using native ES6 node promises.