### PR TITLE
Enable fill paths to be nested properties on the schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,10 +47,10 @@ var fillDoc = function(doc, __fill, cb){
       // if val is not passed, just leave it
       if (arguments.length > 1 && val !== doc){
         if (prop){
-          doc[prop] = multipleProps ? val[prop] : val
+          doc.set(prop, multipleProps ? val[prop] : val)
         } else {
           props.forEach(function(prop){
-            doc[prop] = val[prop]
+            doc.set(prop, val[prop])
           })
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-fill",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Mongoose.js add-on that adds virtual (temporary) async fileds API",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -75,6 +75,12 @@ userSchema.fill('friend', function (callback) {
   callback(null, val)
 })
 
+userSchema.fill('nested.dude', function (callback) {
+  this.db.model('User')
+        .findOne({_id: this.dude})
+        .exec(callback)
+})
+
 const User = mongoose.model('User', userSchema)
 const Pet = mongoose.model('Pet', petSchema)
 
@@ -190,6 +196,19 @@ test('fill friend nested', async t => {
     t.ok(users[0].friend.accounts, 'user1 friend.accounts filled')
     t.is(users[0].friend.accounts[0].upper, 'GOOGLE_X', 'user1 friend filled')
     t.ok(users[1].friend, 'user2 friend filled')
+    t.end()
+  } catch (err) {
+    t.error(err);
+  }
+})
+
+test('fill nested dude', async t => {
+  try {
+    const users = await User
+      .find({ name: 'Jane' })
+      .fill('nested.dude');
+    t.ok(users[0].nested.dude, 'user2 nested dude filled')
+    t.is(users[0].nested.dude.name, 'Alex', 'user2 nested dude filled')
     t.end()
   } catch (err) {
     t.error(err);


### PR DESCRIPTION
Enables a fill to be placed on a nest property of a schema, not only a top-level property.