### PR TITLE
Removed null check for result array

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,9 +262,6 @@ mongoose.Query.prototype.exec = function (op, cb) {
                   }
 
                   results.forEach(function(r, i){
-                    if (!r){
-                      return
-                    }
                     var doc = docs[i]
 
                     var spreadProps = multipleProps


### PR DESCRIPTION
This PR proposes removing a null check from the `exec` callback.

Currently when the filled values are not truthy (e.g. `null` or `0`), it will not be filled into the virtual field, even when the `default` value is specified. There are cases where filling in a falsy value is part of the expected behavior, though.

Please advise if this is the correct approach to this. Thanks.